### PR TITLE
Fixed CSV escaping by duplicating the wrapper character inside cells

### DIFF
--- a/lib/csv-2-json.js
+++ b/lib/csv-2-json.js
@@ -146,6 +146,16 @@ var splitLine = function (line) {
             stateVariables.startIndex = index + 1;
         }
 
+        else if (character === options.DELIMITER.WRAP && charAfter === options.DELIMITER.WRAP
+            && stateVariables.insideWrapDelimiter) {
+            line = line.slice(0, index) + line.slice(index+1); // Remove the current character from the line
+            index--; // Move to position before to prevent moving ahead and skipping a character
+            lastCharacterIndex--; // Update the value since we removed a character
+
+            if (index + 1 >= lastCharacterIndex) {
+                stateVariables.insideWrapDelimiter = false;
+            }
+        }
         // If we reached a wrap delimiter with a field delimiter after it (ie. *",)
         else if (character === options.DELIMITER.WRAP && charAfter === options.DELIMITER.FIELD) {
             splitLine.push(line.substring(stateVariables.startIndex, index));
@@ -174,11 +184,6 @@ var splitLine = function (line) {
             stateVariables.insideWrapDelimiter = false;
             stateVariables.parsingValue = true;
             stateVariables.startIndex = index + 1;
-        }
-        else if (character === "\\" && charAfter === options.DELIMITER.WRAP && stateVariables.insideWrapDelimiter) {
-            line = line.slice(0, index) + line.slice(index+1); // Remove the current character from the line
-            index--; // Move to position before to prevent moving ahead and skipping a character
-            lastCharacterIndex--; // Update the value since we removed a character
         }
         // Otherwise increment to the next character
         index++;

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -133,7 +133,7 @@ var convertField = function (value) {
     } else if (_.isBoolean(value)) { // If we have a boolean (avoids false being converted to '')
         return options.DELIMITER.WRAP + convertValue(value) + options.DELIMITER.WRAP;
     }
-    value = options.DELIMITER.WRAP && value ? value.replace(new RegExp(options.DELIMITER.WRAP, 'g'), "\\"+options.DELIMITER.WRAP) : value;
+    value = options.DELIMITER.WRAP && value ? value.replace(new RegExp(options.DELIMITER.WRAP, 'g'), options.DELIMITER.WRAP+options.DELIMITER.WRAP) : value;
     return options.DELIMITER.WRAP + convertValue(value) + options.DELIMITER.WRAP; // Otherwise push the current value
 };
 

--- a/test/CSV/quoted/nestedQuotes.csv
+++ b/test/CSV/quoted/nestedQuotes.csv
@@ -1,3 +1,3 @@
 "a string"
 "with a description"
-"with a description and \"quotes\""
+"with a description and ""quotes"""


### PR DESCRIPTION
by CSV standards, escaping characters used as cell value wrappers is done by doubling them.

E.g. `"an "obvious" example"` becomes `"an ""obvious"" example"`